### PR TITLE
added functionality artist tools window

### DIFF
--- a/Scripts/Editor/Windows/ArtistsTools/ArtistsToolsWindow.cs
+++ b/Scripts/Editor/Windows/ArtistsTools/ArtistsToolsWindow.cs
@@ -129,6 +129,8 @@ internal class ArtistsToolsWindow : EditorWindow
     private bool ItMustKeepObjectProperties = true;
     private bool ItMustKeepLocalTransforms = true;
     private bool ItMustMergeComponents = false;
+    private bool IncludeChildren = true;
+    private bool AllMeshColliders = false;
     private int MinimalGridSize = 6;
     private float SpacingMultiplier = 1.5f;
     private Vector3 Offset;
@@ -413,24 +415,45 @@ internal class ArtistsToolsWindow : EditorWindow
 
         GUILayout.Label( "Remove Meshcollider Tool -------------- " , EditorStyles.boldLabel );
 
-        if( GUILayout.Button( "Remove meshcolliders without a mesh !" ) )
+        IncludeChildren = EditorGUILayout.Toggle( "Include children", IncludeChildren );
+        AllMeshColliders = EditorGUILayout.Toggle( "Remove all mesh colliders" , AllMeshColliders );
+
+        if( GUILayout.Button( "Remove meshcolliders !" ) )
         {
             GameObject[] selected_object_array = Selection.gameObjects;
+
+            if( IncludeChildren )
+            {
+                foreach( GameObject mesh_collider_object in selected_object_array )
+                {
+                    MeshCollider[] mesh_collider_array = mesh_collider_object.GetComponentsInChildren<MeshCollider>();
+
+                    foreach( MeshCollider mesh_collider in mesh_collider_array )
+                    {
+                        if( mesh_collider.sharedMesh == null || AllMeshColliders )
+                        {
+                            Undo.DestroyObjectImmediate( mesh_collider );
+                        }
+                    }
+                }
+
+                return;
+            }
 
             foreach( GameObject mesh_collider_object in selected_object_array )
             {
                 MeshCollider mesh_collider = mesh_collider_object.GetComponent<MeshCollider>();
 
-                if( mesh_collider == null )
+                if ( mesh_collider == null)
                 {
                     continue;
                 }
 
-                if( mesh_collider.sharedMesh == null )
+                if( mesh_collider.sharedMesh == null || AllMeshColliders )
                 {
-                    DestroyImmediate( mesh_collider );
+                    Undo.DestroyObjectImmediate( mesh_collider );
                 }
-            }
+            }            
         }
 
         EditorGUILayout.EndScrollView();


### PR DESCRIPTION
Added some funtionality to the artist tool
* can remove all meshcolliders without a mesh from the selected game objects and children
* can remove all meshcolliders from the selected game objects and children
* ctrl+z is supported for unfortunate mistakes
* modifying children is a toggleable option

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/fishingcactus/unitycommoncode/63)
<!-- Reviewable:end -->
