### PR TITLE
Useless Task delegate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.5] - 2023-02-23
+### Fix
+- Remove Task delegate because useless and was preventing System.Threading.Tasks.Task to be used in FishingCactus without specifying the whole path.
+
 ## [1.0.4] - 2022-01-27
 ### Added
 - Add Max attribute for integer and float fields and Optional helper struct

--- a/Runtime/Extensions/MonoBehaviourExtensions.cs
+++ b/Runtime/Extensions/MonoBehaviourExtensions.cs
@@ -1,9 +1,8 @@
-﻿using UnityEngine;
+﻿using System;
+using UnityEngine;
 
 namespace FishingCactus
 {
-    public delegate void Task();
-
     public static class MonoBehaviourExtensions
     {
         public static void SetParent(
@@ -19,21 +18,21 @@ namespace FishingCactus
 
         public static void Invoke(
             this MonoBehaviour mono_behaviour,
-            Task task,
+            Action action,
             float time
             )
         {
-            mono_behaviour.Invoke( task.Method.Name, time );
+            mono_behaviour.Invoke( action.Method.Name, time );
         }
 
         public static void InvokeRepeating(
             this MonoBehaviour mono_behaviour,
-            Task task,
+            Action action,
             float time,
             float repeat_rate
             )
         {
-            mono_behaviour.InvokeRepeating( task.Method.Name, time, repeat_rate );
+            mono_behaviour.InvokeRepeating( action.Method.Name, time, repeat_rate );
         }
 
         public static T GetOrAddComponent<T>(
@@ -45,7 +44,7 @@ namespace FishingCactus
 
         public static Component GetOrAddComponent(
             this MonoBehaviour mono_behaviour,
-            System.Type component_type
+            Type component_type
             )
         {
             return mono_behaviour.GetComponent( component_type ) ?? mono_behaviour.gameObject.AddComponent( component_type );

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.fishingcactus.common-code",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "displayName": "FC - Common Code",
   "description": "Code, Extensions and extra features  for Fishing Cactus Games.",
   "unity": "2020.3",


### PR DESCRIPTION
This was not necessary and `Task` from System.Threading.Tasks couldn't be used in FishingCactus without specifying the whole path