### PR TITLE
add custompropertydrawer attribute on enumdictionary property drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.16] - 2023-10-16
+### Added
+- Add CustomPropertyDrawer attribute to EnumDictionary's property drawer
+
 ## [1.0.15] - 2023-10-04
 ### Added
 - Add NetworkStatusChecker to check for Internet availability

--- a/Editor/EnumDictionaryPropertyDrawer.cs
+++ b/Editor/EnumDictionaryPropertyDrawer.cs
@@ -1,6 +1,7 @@
 ﻿using UnityEngine;
 using UnityEditor;
 
+[CustomPropertyDrawer(typeof(EnumDictionary<,>),true)]
 public class EnumDictionaryPropertyDrawer : PropertyDrawer
 {
     // -- FIELDS

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.fishingcactus.common-code",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "displayName": "FC - Common Code",
   "description": "Code, Extensions and extra features  for Fishing Cactus Games.",
   "unity": "2020.3",


### PR DESCRIPTION
Add Custom property drawer attribute on the EnumDictionary property drawer to avoid creating class from EnumDictionary and class  from EnumDictionaryPropertyDrawer 