### PR TITLE
add subclasspicker attribute and drawer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [1.0.18] - 2023-11-13
+###Added
+- Add SubClassPicker attribute
+
 ## [1.0.17] - 2023-10-27
 ### Updated
 - Doc comment for MathMod + rectify the example

--- a/Editor/AttributesDrawer/SubClassPickerAttributeDrawer.cs
+++ b/Editor/AttributesDrawer/SubClassPickerAttributeDrawer.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using UnityEditor;
+using UnityEngine;
+
+namespace FishingCactus
+{
+    public class SubClassPickerAttributeDrawer : MonoBehaviour
+    {
+        [CustomPropertyDrawer( typeof( SubClassPicker ) )]
+        public class SubClassPickerDrawer : PropertyDrawer
+        {
+            // -- FIELDS
+
+            private const string DefaultDisplay = "Pick a type";
+
+            // -- METHODS
+
+            private IEnumerable<Type> GetSubClasses(
+                Type base_type
+                )
+            {
+                return Assembly.GetAssembly( base_type )
+                    .GetTypes()
+                    .Where( type => type.IsClass && !type.IsAbstract && base_type.IsAssignableFrom( type ) );
+            }
+
+            // -- UNITY
+
+            public override float GetPropertyHeight(
+                SerializedProperty property,
+                GUIContent label
+                )
+            {
+                return EditorGUI.GetPropertyHeight( property, label );
+            }
+
+            public override void OnGUI(
+                Rect position,
+                SerializedProperty property,
+                GUIContent label
+                )
+            {
+                Type field_type = fieldInfo.FieldType;
+
+                string type_name = property.managedReferenceValue?.GetType().Name ?? DefaultDisplay;
+
+                Rect drop_down_rect = position;
+
+                drop_down_rect.x += EditorGUIUtility.labelWidth + 2;
+                drop_down_rect.width -= EditorGUIUtility.labelWidth + 2;
+                drop_down_rect.height = EditorGUIUtility.singleLineHeight;
+
+                if( EditorGUI.DropdownButton( drop_down_rect, new( type_name ), FocusType.Keyboard ) )
+                {
+                    GenericMenu menu = new GenericMenu();
+                    menu.AddItem( new GUIContent( "None" ), property.managedReferenceValue == null, () =>
+                    {
+                        property.managedReferenceValue = null;
+                        property.serializedObject.ApplyModifiedProperties();
+                    } );
+
+                    foreach( Type type in GetSubClasses( field_type ) )
+                    {
+                        menu.AddItem( new GUIContent( type.Name ), type_name == type.Name, () =>
+                        {
+                            property.managedReferenceValue = type.GetConstructor( Type.EmptyTypes ).Invoke( null );
+                            property.serializedObject.ApplyModifiedProperties();
+                        } );
+
+                        menu.ShowAsContext();
+                    }
+                }
+
+                EditorGUI.PropertyField( position, property, label, true );
+            }
+        }
+    }
+}

--- a/Editor/AttributesDrawer/SubClassPickerAttributeDrawer.cs.meta
+++ b/Editor/AttributesDrawer/SubClassPickerAttributeDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c377ae8a69cfa62408240007ef2ed94f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/Attributes/SubClassPickerAttribute.cs
+++ b/Runtime/Attributes/SubClassPickerAttribute.cs
@@ -1,0 +1,6 @@
+using UnityEngine;
+
+namespace FishingCactus
+{
+    public class SubClassPicker : PropertyAttribute { }
+}

--- a/Runtime/Attributes/SubClassPickerAttribute.cs.meta
+++ b/Runtime/Attributes/SubClassPickerAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64b3384240769674e9d119377d94a81f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.fishingcactus.common-code",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "displayName": "FC - Common Code",
   "description": "Code, Extensions and extra features  for Fishing Cactus Games.",
   "unity": "2020.3",


### PR DESCRIPTION
Add the SubClassPicker Atribute.
Use it with the SerializeRerefence Attribute to chose a non-monobehaviour class 

![image](https://github.com/FishingCactus/UnityCommonCode/assets/96061068/1f9d5bcc-9a9a-433f-a439-d97d45c2ee66)

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/FishingCactus/UnityCommonCode/104)
<!-- Reviewable:end -->
